### PR TITLE
ci: update artifact actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           mv dist/${bin_name}${{ matrix.ext }} dist/${out_name}${{ matrix.ext }}
           cd dist
           zip ../${out_name}.zip ${out_name}${{ matrix.ext }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: kbd-overlay-${{ matrix.target }}
           path: kbd-overlay-${{ matrix.target }}.zip
@@ -54,7 +54,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: dist
       - uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
- fix CI by upgrading to actions/upload-artifact and download-artifact v4

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6895822943dc83339ab1317a39668caf