### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
       - name: Test
@@ -36,7 +33,7 @@ jobs:
       - name: Package binary
         shell: bash
         run: |
-          bin_name=kbd_overlay
+          bin_name=kbd_layout_overlay
           out_name=kbd-overlay-${{ matrix.target }}
           bin_path=target/${{ matrix.target }}/release/${bin_name}${{ matrix.ext }}
           mkdir dist

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -43,7 +43,10 @@ pub fn run(image_path: &Path, width: u32, height: u32, opacity: f32) -> Result<(
     // make window click-through and shadowless
     #[cfg(target_os = "macos")]
     {
-        window.set_ignores_mouse_events(true);
+        // winit 0.28 removed `set_ignores_mouse_events` in favour of the
+        // cross-platform `set_cursor_hittest`. Disable hit testing to allow
+        // the overlay window to be click-through.
+        let _ = window.set_cursor_hittest(false);
         window.set_has_shadow(false);
     }
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to use `dtolnay/rust-toolchain`
- correct binary name for packaging
- replace removed macOS API with `set_cursor_hittest` so overlay builds

## Testing
- `cargo test`
- `cargo check --target aarch64-apple-darwin` *(fails: couldn't read `nsworkspace.rs` in `appkit-nsworkspace-bindings`)*

------
https://chatgpt.com/codex/tasks/task_e_689584e2c32c8333ae60724b05f4e6ac