### PR TITLE
Clarify image load fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Displays an image overlay in response to a keyboard shortcut.
 Running the binary launches a background listener. Hold
 `Ctrl + Alt + Shift + Slash` to show the overlay and release any key to hide
 it. The image is centered on the monitor with the active window, falling back
-to the display under the mouse cursor. If no image is configured a built-in
-`keymap.png` (742×235) is used. If the configured image cannot be loaded the
-hotkey is ignored and an error is printed.
+to the display under the mouse cursor. If no image is configured or the
+configured path is missing, a built-in `keymap.png` (742×235) from the `assets`
+directory is used. If a configured image cannot be loaded an error is printed
+and the built-in image is used instead.
 
 Configuration options can be supplied on the command line:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,12 @@ impl Config {
             .join("kbd_overlay");
         let path = dir.join("config.json");
         if let Ok(bytes) = fs::read(&path) {
-            if let Ok(cfg) = serde_json::from_slice(&bytes) {
+            if let Ok(mut cfg) = serde_json::from_slice::<Self>(&bytes) {
+                if let Some(p) = &cfg.image_path {
+                    if !p.exists() {
+                        cfg.image_path = None;
+                    }
+                }
                 return Ok(cfg);
             }
         }

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -74,7 +74,10 @@ pub fn run(image_path: Option<&Path>, width: u32, height: u32, opacity: f32) -> 
         Some(path) => match image::open(path) {
             Ok(i) => Some(i.to_rgba8()),
             Err(e) => {
-                eprintln!("failed to load image {}: {e}", path.display());
+                eprintln!(
+                    "failed to load image {}: {e}; falling back to built-in image",
+                    path.display()
+                );
                 match image::load_from_memory(DEFAULT_IMAGE) {
                     Ok(i) => Some(i.to_rgba8()),
                     Err(e) => {


### PR DESCRIPTION
## Summary
- Ignore missing configured image path and fall back to bundled `keymap.png`
- Document that absent or missing image paths default to the asset-provided keymap

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68959a7cc4d883338a60a9cd19004b60