### PR TITLE
Clarify image load fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ Displays an image overlay in response to a keyboard shortcut.
 Running the binary launches a background listener. Hold
 `Ctrl + Alt + Shift + Slash` to show the overlay and release any key to hide
 it. The image is centered on the monitor with the active window, falling back
-to the display under the mouse cursor. If no image is configured a built-in
-`keymap.png` (742×235) is used. If the configured image cannot be loaded the
-hotkey is ignored and an error is printed.
+to the display under the mouse cursor. If no image is configured or the
+configured path is missing, the application looks for a `keymap.png` next to
+the executable and uses it if found. Otherwise a built-in `keymap.png`
+(742×235) from the `assets` directory is used. If a configured image cannot be
+loaded an error is printed and the same `keymap.png` lookup is performed before
+falling back to the built-in image.
 
 Configuration options can be supplied on the command line:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,12 @@ impl Config {
             .join("kbd_overlay");
         let path = dir.join("config.json");
         if let Ok(bytes) = fs::read(&path) {
-            if let Ok(cfg) = serde_json::from_slice(&bytes) {
+            if let Ok(mut cfg) = serde_json::from_slice::<Self>(&bytes) {
+                if let Some(p) = &cfg.image_path {
+                    if !p.exists() {
+                        cfg.image_path = None;
+                    }
+                }
                 return Ok(cfg);
             }
         }


### PR DESCRIPTION
## Summary
- Ignore missing configured image path and fall back to bundled `keymap.png`
- Document that absent or missing image paths default to the asset-provided keymap
- Search for `keymap.png` alongside the executable before using the built-in image

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68959a7cc4d883338a60a9cd19004b60