### PR TITLE
Add structured logging and document RUST_LOG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +877,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "home"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +890,12 @@ checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "image"
@@ -910,6 +935,17 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -968,7 +1004,9 @@ dependencies = [
  "clap",
  "dirs",
  "display-info",
+ "env_logger",
  "image",
+ "log",
  "mouse_position",
  "rdev",
  "serde",
@@ -1940,6 +1978,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2382,6 +2429,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-wsapoll"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ anyhow = "1"
 dirs = "5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+log = "0.4"
+env_logger = "0.10"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.11"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ configuration file.
 `kbd_layout_overlay diagnose` prints detected monitors and their scale
 factors and exits.
 
+Enable debug or informational output by setting the `RUST_LOG` environment
+variable before running the application. For example:
+
+```
+RUST_LOG=debug kbd_layout_overlay
+```
+
 ## Autostart helper
 
 The CLI exposes commands to register the application to run at login on

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -82,11 +82,11 @@ mod imp {
 mod imp {
     use super::*;
     pub fn enable() -> Result<()> {
-        println!("Autostart not supported on this platform.");
+        log::warn!("Autostart not supported on this platform.");
         Ok(())
     }
     pub fn disable() -> Result<()> {
-        println!("Autostart not supported on this platform.");
+        log::warn!("Autostart not supported on this platform.");
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod overlay {
     use anyhow::Result;
     use std::path::Path;
     pub fn run(_img: Option<&Path>, _w: u32, _h: u32, _o: f32) -> Result<()> {
-        println!("overlay not supported on this platform");
+        log::warn!("overlay not supported on this platform");
         Ok(())
     }
 }
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
+use log::warn;
 
 #[derive(Parser)]
 #[command(author, version, about)]
@@ -59,6 +60,7 @@ enum AutostartAction {
 }
 
 fn main() -> Result<()> {
+    env_logger::init();
     let cli = Cli::parse();
 
     match &cli.command {
@@ -109,11 +111,11 @@ fn diagnose() {
     let event_loop = winit::event_loop::EventLoop::<()>::new();
     for (i, m) in event_loop.available_monitors().enumerate() {
         let name = m.name().unwrap_or_else(|| "unknown".into());
-        println!("Monitor {i}: {name}, scale {}", m.scale_factor());
+        log::info!("Monitor {i}: {name}, scale {}", m.scale_factor());
     }
 }
 
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
 fn diagnose() {
-    println!("diagnose not supported on this platform");
+    warn!("diagnose not supported on this platform");
 }

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -8,6 +8,7 @@ use active_win_pos_rs::get_active_window;
 use anyhow::Result;
 use display_info::DisplayInfo;
 use mouse_position::mouse_position::Mouse;
+use log::{error, warn};
 use winit::{
     dpi::{LogicalSize, PhysicalPosition},
     event::{Event, WindowEvent},
@@ -146,7 +147,7 @@ fn load_image(image_path: Option<&Path>) -> Option<RgbaImage> {
     if let Some(path) = image_path {
         match image::open(path) {
             Ok(i) => return Some(i.to_rgba8()),
-            Err(e) => eprintln!("failed to load image {}: {e}", path.display()),
+            Err(e) => error!("failed to load image {}: {e}", path.display()),
         }
     }
 
@@ -156,7 +157,7 @@ fn load_image(image_path: Option<&Path>) -> Option<RgbaImage> {
             Ok(i) => return Some(i.to_rgba8()),
             Err(e) => {
                 if exe.exists() {
-                    eprintln!("failed to load {}: {e}", exe.display());
+                    error!("failed to load {}: {e}", exe.display());
                 }
             }
         }
@@ -164,11 +165,11 @@ fn load_image(image_path: Option<&Path>) -> Option<RgbaImage> {
 
     match image::load_from_memory(DEFAULT_IMAGE) {
         Ok(i) => {
-            eprintln!("falling back to built-in image");
+            warn!("falling back to built-in image");
             Some(i.to_rgba8())
         }
         Err(e) => {
-            eprintln!("failed to load built-in image: {e}");
+            error!("failed to load built-in image: {e}");
             None
         }
     }


### PR DESCRIPTION
## Summary
- add `log`/`env_logger` dependencies and initialize logging
- replace println/eprintln calls with appropriate log macros
- document enabling debug output via `RUST_LOG`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6895a4a56500833393d271ca3be3e657