### PR TITLE
Fix overlay rendering and add dark mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Displays an image overlay in response to a keyboard shortcut.
 
 Running the binary launches a background listener. Hold
 `Ctrl + Alt + Shift + Slash` to show the overlay and release any key to hide
-it. The image is centered on the monitor with the active window, falling back
-to the display under the mouse cursor. If no image is configured or the
+it. The image is centered horizontally and aligned to the bottom of the monitor
+with the active window, falling back to the display under the mouse cursor. If no image is configured or the
 configured path is missing, the application looks for a `keymap.png` next to
 the executable and uses it if found. Otherwise a built-in `keymap.png`
 (742×235) from the `assets` directory is used. If a configured image cannot be
@@ -17,7 +17,7 @@ falling back to the built-in image.
 Configuration options can be supplied on the command line:
 
 ```
-kbd_layout_overlay --image path/to.png --width 742 --height 235 --opacity 0.3 --autostart true
+kbd_layout_overlay --image path/to.png --width 742 --height 235 --opacity 0.3 --invert false --autostart true
 ```
 
 Use `--autostart true` to enable starting the application at login or
@@ -53,6 +53,6 @@ user's home directory and loaded with `launchctl`.
 
 - hotkey shows and hides overlay instantly
 - overlay ignores mouse clicks
-- image is centered on the active monitor (cursor monitor fallback)
+- image appears at the bottom center of the active monitor (cursor monitor fallback)
 - size consistent on HiDPI displays
 - autostart launches app after reboot

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,8 @@ pub struct Config {
     pub width: u32,
     pub height: u32,
     pub opacity: f32,
+    #[serde(default)]
+    pub invert: bool,
     pub autostart: bool,
 }
 
@@ -20,6 +22,7 @@ impl Default for Config {
             width: 742,
             height: 235,
             opacity: 0.3,
+            invert: false,
             autostart: false,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod overlay;
 mod overlay {
     use anyhow::Result;
     use std::path::Path;
-    pub fn run(_img: Option<&Path>, _w: u32, _h: u32, _o: f32) -> Result<()> {
+    pub fn run(_img: Option<&Path>, _w: u32, _h: u32, _o: f32, _i: bool) -> Result<()> {
         log::warn!("overlay not supported on this platform");
         Ok(())
     }
@@ -35,6 +35,9 @@ struct Cli {
     /// Overlay opacity (0.0 - 1.0)
     #[arg(long)]
     opacity: Option<f32>,
+    /// Invert image colors
+    #[arg(long)]
+    invert: Option<bool>,
     /// Enable or disable autostart
     #[arg(long)]
     autostart: Option<bool>,
@@ -85,6 +88,9 @@ fn main() -> Result<()> {
             if let Some(o) = cli.opacity {
                 cfg.opacity = o;
             }
+            if let Some(i) = cli.invert {
+                cfg.invert = i;
+            }
             if let Some(a) = cli.autostart {
                 cfg.autostart = a;
             }
@@ -99,6 +105,7 @@ fn main() -> Result<()> {
                 cfg.width,
                 cfg.height,
                 cfg.opacity,
+                cfg.invert,
             )?;
         }
     }


### PR DESCRIPTION
## Summary
- resize keymap image to match configured dimensions to avoid skewing
- position overlay at the bottom center of the active monitor
- add optional `--invert` flag to render a negative-color (dark mode) overlay

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6895a8dd7a6c8333957681edc007e57b