### PR TITLE
Add configurable hotkey for overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,6 +1671,7 @@ dependencies = [
  "core-graphics 0.19.2",
  "lazy_static",
  "libc",
+ "serde",
  "winapi",
  "x11",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 log = "0.4"
 env_logger = "0.10"
+rdev = { version = "0.5", features = ["serialize"] }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.11"
@@ -23,7 +24,6 @@ windows-sys = { version = "0.48", features = [
 winit = { version = "0.28", features = ["serde"] }
 softbuffer = "0.3"
 image = "0.24"
-rdev = "0.5"
 display-info = "0.5"
 active-win-pos-rs = "0.9"
 mouse_position = "0.1"

--- a/README.md
+++ b/README.md
@@ -18,12 +18,26 @@ falling back to the built-in image.
 Configuration options can be supplied on the command line:
 
 ```
-kbd_layout_overlay --image path/to.png --width 742 --height 235 --opacity 0.3 --invert false --persist true --autostart true
+kbd_layout_overlay --image path/to.png --width 742 --height 235 --opacity 0.3 --invert false --persist true --autostart true --hotkey ControlLeft+Alt+ShiftLeft+Slash
 ```
 
 Use `--autostart true` to enable starting the application at login or
 `--autostart false` to disable it. The preference is saved to the
 configuration file.
+
+Use `--hotkey` followed by a `+` separated list of key names to configure a
+different shortcut.
+
+Key names follow winit's `Key` enumeration. On macOS the Option key is
+reported as `Alt` and the Command key as `MetaLeft`/`MetaRight`. The parser also
+accepts `Option`/`Opt` in place of `Alt` and `Command`/`Cmd` in place of
+`MetaLeft`.
+
+Common combinations:
+
+- **Windows:** `Ctrl+Alt+Shift+Slash` (default), `Ctrl+Alt+K`
+- **macOS:** `Cmd+Option+Shift+/`, `Cmd+Option+K`
+- **Linux:** `Ctrl+Alt+Shift+Slash`, `Meta+Alt+K` (Meta = Windows/Super key)
 
 `kbd_layout_overlay diagnose` prints detected monitors and their scale
 factors and exits.

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
+use rdev::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -14,6 +15,9 @@ pub struct Config {
     pub invert: bool,
     #[serde(default)]
     pub persist: bool,
+    #[serde(default = "default_hotkey")]
+    pub hotkey: Vec<Key>,
+    #[serde(default)]
     pub autostart: bool,
 }
 
@@ -26,9 +30,14 @@ impl Default for Config {
             opacity: 0.3,
             invert: false,
             persist: false,
+            hotkey: default_hotkey(),
             autostart: false,
         }
     }
+}
+
+fn default_hotkey() -> Vec<Key> {
+    vec![Key::ControlLeft, Key::Alt, Key::ShiftLeft, Key::Slash]
 }
 
 impl Config {

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -44,6 +44,7 @@ pub fn run(
     opacity: f32,
     invert: bool,
     persist: bool,
+    hotkey: Vec<rdev::Key>,
 ) -> Result<()> {
     let event_loop = EventLoopBuilder::<OverlayEvent>::with_user_event().build();
     let proxy = event_loop.create_proxy();
@@ -105,10 +106,10 @@ pub fn run(
     // Spawn listener thread for hotkey
     {
         let proxy = proxy.clone();
+        let required = hotkey;
         std::thread::spawn(move || {
             use rdev::{listen, EventType, Key};
             use std::collections::HashSet;
-            let required: [Key; 4] = [Key::ControlLeft, Key::Alt, Key::ShiftLeft, Key::Slash];
             let mut pressed = HashSet::new();
             let mut combo_active = false;
             let _ = listen(move |event| match event.event_type {


### PR DESCRIPTION
## Summary
- allow configuring overlay activation keys via `--hotkey` CLI option
- persist hotkey combination in config file
- use configured keys in runtime listener with validation
- document platform-specific key names and examples, including Option/Cmd aliases

## Testing
- `cargo test` *(fails: The system library `xi` required by crate `x11` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895aef7da68833381788ddd8017605f