### PR TITLE
Replace rdev hotkey with platform APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b37fd8a23464e913e3fcc1ff2d347c06d77f9101ee680c42b32d020508dc834"
 dependencies = [
  "appkit-nsworkspace-bindings",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics 0.23.2",
  "objc",
  "windows 0.48.0",
@@ -487,21 +487,6 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667fdc068627a2816b9ff831201dd9864249d6ee8d190b9532357f1fc0f61ea7"
-dependencies = [
- "bitflags 1.3.2",
- "block",
- "core-foundation 0.9.4",
- "core-graphics 0.21.0",
- "foreign-types 0.3.2",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
@@ -509,7 +494,7 @@ dependencies = [
  "bitflags 1.3.2",
  "block",
  "cocoa-foundation",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics 0.22.3",
  "foreign-types 0.3.2",
  "libc",
@@ -525,7 +510,7 @@ dependencies = [
  "bitflags 1.3.2",
  "block",
  "cocoa-foundation",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics 0.23.2",
  "foreign-types 0.5.0",
  "libc",
@@ -540,7 +525,7 @@ checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
 dependencies = [
  "bitflags 1.3.2",
  "block",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics-types",
  "libc",
  "objc",
@@ -570,29 +555,13 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
-dependencies = [
- "core-foundation-sys 0.7.0",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
- "core-foundation-sys 0.8.7",
+ "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -602,36 +571,12 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.7.0",
- "foreign-types 0.3.2",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a67c4378cf203eace8fb6567847eb641fd6ff933c1145a115c6ee820ebb978"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "foreign-types 0.3.2",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics-types",
  "foreign-types 0.3.2",
  "libc",
@@ -644,7 +589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics-types",
  "foreign-types 0.5.0",
  "libc",
@@ -657,7 +602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "libc",
 ]
 
@@ -1417,7 +1362,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg_aliases",
  "cgl",
- "core-foundation 0.9.4",
+ "core-foundation",
  "dispatch",
  "glutin_egl_sys",
  "glutin_glx_sys",
@@ -1815,6 +1760,8 @@ dependencies = [
  "active-win-pos-rs",
  "anyhow",
  "clap",
+ "core-foundation",
+ "core-graphics 0.23.2",
  "dirs",
  "display-info",
  "eframe",
@@ -1822,7 +1769,6 @@ dependencies = [
  "image",
  "log",
  "mouse_position",
- "rdev",
  "serde",
  "serde_json",
  "softbuffer",
@@ -2671,23 +2617,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdev"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00552ca2dc2f93b84cd7b5581de49549411e4e41d89e1c691bcb93dc4be360c3"
-dependencies = [
- "cocoa 0.22.0",
- "core-foundation 0.7.0",
- "core-foundation-sys 0.7.0",
- "core-graphics 0.19.2",
- "lazy_static",
- "libc",
- "serde",
- "winapi",
- "x11",
 ]
 
 [[package]]
@@ -3633,7 +3562,7 @@ version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db67ae75a9405634f5882791678772c94ff5f16a66535aae186e26aa0841fc8b"
 dependencies = [
- "core-foundation 0.9.4",
+ "core-foundation",
  "home",
  "jni",
  "log",
@@ -4074,7 +4003,7 @@ dependencies = [
  "android-activity",
  "bitflags 1.3.2",
  "cfg_aliases",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics 0.22.3",
  "dispatch",
  "instant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 log = "0.4"
 env_logger = "0.10"
-rdev = { version = "0.5", features = ["serialize"] }
 image = "0.24"
 eframe = { version = "0.24", default-features = false, features = ["glow"] }
 tray-icon = { version = "0.9", optional = true }
@@ -21,6 +20,7 @@ winreg = "0.11"
 windows-sys = { version = "0.48", features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Input_KeyboardAndMouse",
 ] }
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
@@ -29,6 +29,10 @@ softbuffer = "0.3"
 display-info = "0.5"
 active-win-pos-rs = "0.9"
 mouse_position = "0.1"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+core-graphics = "0.23"
+core-foundation = "0.9"
 
 [features]
 default = []

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,6 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
-use rdev::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -16,7 +15,7 @@ pub struct Config {
     #[serde(default)]
     pub persist: bool,
     #[serde(default = "default_hotkey")]
-    pub hotkey: Vec<Key>,
+    pub hotkey: Vec<String>,
     #[serde(default)]
     pub autostart: bool,
 }
@@ -36,8 +35,13 @@ impl Default for Config {
     }
 }
 
-fn default_hotkey() -> Vec<Key> {
-    vec![Key::ControlLeft, Key::Alt, Key::ShiftLeft, Key::Slash]
+fn default_hotkey() -> Vec<String> {
+    vec![
+        "ControlLeft".into(),
+        "Alt".into(),
+        "ShiftLeft".into(),
+        "Slash".into(),
+    ]
 }
 
 impl Config {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -4,7 +4,6 @@ use anyhow::{anyhow, Result};
 use eframe::{egui, App, Frame};
 use egui::{Color32, ColorImage, TextureHandle};
 use image::{imageops::FilterType, RgbaImage};
-use rdev::Key;
 
 use crate::config::Config;
 
@@ -159,8 +158,8 @@ impl App for GuiApp {
                             egui::Event::Key {
                                 key, pressed: true, ..
                             } => {
-                                if let Some(k) = egui_to_rdev(*key) {
-                                    let mut keys = modifiers_to_rdev(i.modifiers);
+                                if let Some(k) = egui_key_to_name(*key) {
+                                    let mut keys = modifiers_to_names(i.modifiers);
                                     if !keys.contains(&k) {
                                         keys.push(k);
                                     }
@@ -170,8 +169,8 @@ impl App for GuiApp {
                                 }
                             }
                             egui::Event::Text(t) => {
-                                if let Some(k) = text_to_rdev(t) {
-                                    let mut keys = modifiers_to_rdev(i.modifiers);
+                                if let Some(k) = text_to_name(t) {
+                                    let mut keys = modifiers_to_names(i.modifiers);
                                     if !keys.contains(&k) {
                                         keys.push(k);
                                     }
@@ -223,121 +222,118 @@ fn load_image(path: Option<&PathBuf>) -> Option<RgbaImage> {
         .map(|i| i.to_rgba8())
 }
 
-fn hotkey_to_string(keys: &[Key]) -> String {
-    keys.iter()
-        .map(|k| format!("{:?}", k))
-        .collect::<Vec<_>>()
-        .join("+")
+fn hotkey_to_string(keys: &[String]) -> String {
+    keys.join("+")
 }
 
-fn modifiers_to_rdev(m: egui::Modifiers) -> Vec<Key> {
+fn modifiers_to_names(m: egui::Modifiers) -> Vec<String> {
     let mut keys = Vec::new();
     if m.ctrl {
-        keys.push(Key::ControlLeft);
+        keys.push("ControlLeft".into());
     }
     if m.shift {
-        keys.push(Key::ShiftLeft);
+        keys.push("ShiftLeft".into());
     }
     if m.alt {
-        keys.push(Key::Alt);
+        keys.push("Alt".into());
     }
     if m.mac_cmd {
-        keys.push(Key::MetaLeft);
+        keys.push("Meta".into());
     }
     keys
 }
 
-fn egui_to_rdev(key: egui::Key) -> Option<Key> {
+fn egui_key_to_name(key: egui::Key) -> Option<String> {
     use egui::Key::*;
-    let k = match key {
-        ArrowDown => Key::DownArrow,
-        ArrowLeft => Key::LeftArrow,
-        ArrowRight => Key::RightArrow,
-        ArrowUp => Key::UpArrow,
-        Escape => Key::Escape,
-        Tab => Key::Tab,
-        Backspace => Key::Backspace,
-        Enter => Key::Return,
-        Space => Key::Space,
-        Insert => Key::Insert,
-        Delete => Key::Delete,
-        Home => Key::Home,
-        End => Key::End,
-        PageUp => Key::PageUp,
-        PageDown => Key::PageDown,
-        Minus => Key::Minus,
-        PlusEquals => Key::Equal,
-        Num0 => Key::Num0,
-        Num1 => Key::Num1,
-        Num2 => Key::Num2,
-        Num3 => Key::Num3,
-        Num4 => Key::Num4,
-        Num5 => Key::Num5,
-        Num6 => Key::Num6,
-        Num7 => Key::Num7,
-        Num8 => Key::Num8,
-        Num9 => Key::Num9,
-        A => Key::KeyA,
-        B => Key::KeyB,
-        C => Key::KeyC,
-        D => Key::KeyD,
-        E => Key::KeyE,
-        F => Key::KeyF,
-        G => Key::KeyG,
-        H => Key::KeyH,
-        I => Key::KeyI,
-        J => Key::KeyJ,
-        K => Key::KeyK,
-        L => Key::KeyL,
-        M => Key::KeyM,
-        N => Key::KeyN,
-        O => Key::KeyO,
-        P => Key::KeyP,
-        Q => Key::KeyQ,
-        R => Key::KeyR,
-        S => Key::KeyS,
-        T => Key::KeyT,
-        U => Key::KeyU,
-        V => Key::KeyV,
-        W => Key::KeyW,
-        X => Key::KeyX,
-        Y => Key::KeyY,
-        Z => Key::KeyZ,
-        F1 => Key::F1,
-        F2 => Key::F2,
-        F3 => Key::F3,
-        F4 => Key::F4,
-        F5 => Key::F5,
-        F6 => Key::F6,
-        F7 => Key::F7,
-        F8 => Key::F8,
-        F9 => Key::F9,
-        F10 => Key::F10,
-        F11 => Key::F11,
-        F12 => Key::F12,
+    let name = match key {
+        ArrowDown => "DownArrow",
+        ArrowLeft => "LeftArrow",
+        ArrowRight => "RightArrow",
+        ArrowUp => "UpArrow",
+        Escape => "Escape",
+        Tab => "Tab",
+        Backspace => "Backspace",
+        Enter => "Return",
+        Space => "Space",
+        Insert => "Insert",
+        Delete => "Delete",
+        Home => "Home",
+        End => "End",
+        PageUp => "PageUp",
+        PageDown => "PageDown",
+        Minus => "Minus",
+        PlusEquals => "Equal",
+        Num0 => "Num0",
+        Num1 => "Num1",
+        Num2 => "Num2",
+        Num3 => "Num3",
+        Num4 => "Num4",
+        Num5 => "Num5",
+        Num6 => "Num6",
+        Num7 => "Num7",
+        Num8 => "Num8",
+        Num9 => "Num9",
+        A => "KeyA",
+        B => "KeyB",
+        C => "KeyC",
+        D => "KeyD",
+        E => "KeyE",
+        F => "KeyF",
+        G => "KeyG",
+        H => "KeyH",
+        I => "KeyI",
+        J => "KeyJ",
+        K => "KeyK",
+        L => "KeyL",
+        M => "KeyM",
+        N => "KeyN",
+        O => "KeyO",
+        P => "KeyP",
+        Q => "KeyQ",
+        R => "KeyR",
+        S => "KeyS",
+        T => "KeyT",
+        U => "KeyU",
+        V => "KeyV",
+        W => "KeyW",
+        X => "KeyX",
+        Y => "KeyY",
+        Z => "KeyZ",
+        F1 => "F1",
+        F2 => "F2",
+        F3 => "F3",
+        F4 => "F4",
+        F5 => "F5",
+        F6 => "F6",
+        F7 => "F7",
+        F8 => "F8",
+        F9 => "F9",
+        F10 => "F10",
+        F11 => "F11",
+        F12 => "F12",
         _ => return None,
     };
-    Some(k)
+    Some(name.into())
 }
 
-fn text_to_rdev(t: &str) -> Option<Key> {
+fn text_to_name(t: &str) -> Option<String> {
     match t {
-        "/" | "?" => Some(Key::Slash),
-        "\\" | "|" => Some(Key::BackSlash),
-        "," | "<" => Some(Key::Comma),
-        "." | ">" => Some(Key::Dot),
-        ";" | ":" => Some(Key::SemiColon),
-        "'" | "\"" => Some(Key::Quote),
-        "`" | "~" => Some(Key::BackQuote),
-        "[" | "{" => Some(Key::LeftBracket),
-        "]" | "}" => Some(Key::RightBracket),
-        "-" | "_" => Some(Key::Minus),
-        "=" | "+" => Some(Key::Equal),
+        "/" | "?" => Some("Slash".into()),
+        "\\" | "|" => Some("BackSlash".into()),
+        "," | "<" => Some("Comma".into()),
+        "." | ">" => Some("Dot".into()),
+        ";" | ":" => Some("SemiColon".into()),
+        "'" | "\"" => Some("Quote".into()),
+        "`" | "~" => Some("BackQuote".into()),
+        "[" | "{" => Some("LeftBracket".into()),
+        "]" | "}" => Some("RightBracket".into()),
+        "-" | "_" => Some("Minus".into()),
+        "=" | "+" => Some("Equal".into()),
         _ => None,
     }
 }
 
-fn parse_hotkey_str(input: &str) -> Result<Vec<Key>> {
+fn parse_hotkey_str(input: &str) -> Result<Vec<String>> {
     if input.trim().is_empty() {
         return Ok(Vec::new());
     }
@@ -345,43 +341,35 @@ fn parse_hotkey_str(input: &str) -> Result<Vec<Key>> {
     parse_hotkey(&parts)
 }
 
-fn parse_hotkey(names: &[String]) -> Result<Vec<Key>> {
+fn parse_hotkey(names: &[String]) -> Result<Vec<String>> {
     names
         .iter()
         .map(|n| {
-            let name = if n.eq_ignore_ascii_case("option") || n.eq_ignore_ascii_case("opt") {
-                "Alt"
+            if n.eq_ignore_ascii_case("option") || n.eq_ignore_ascii_case("opt") {
+                Ok("Alt".to_string())
             } else if n.eq_ignore_ascii_case("command") || n.eq_ignore_ascii_case("cmd") {
-                "MetaLeft"
+                Ok("Meta".to_string())
             } else {
-                n.as_str()
-            };
-            serde_json::from_str::<Key>(&format!("\"{}\"", name))
-                .map_err(|_| anyhow!("invalid key name: {n}"))
+                Ok(n.clone())
+            }
         })
         .collect()
 }
 
-fn validate_hotkey(keys: &[Key]) -> Result<()> {
-    if !keys.iter().any(|&k| is_modifier(k)) {
+fn validate_hotkey(keys: &[String]) -> Result<()> {
+    if !keys.iter().any(|k| is_modifier(k)) {
         return Err(anyhow!("hotkey must include at least one modifier key"));
     }
-    if !keys.iter().any(|&k| !is_modifier(k)) {
+    if !keys.iter().any(|k| !is_modifier(k)) {
         return Err(anyhow!("hotkey must include at least one non-modifier key"));
     }
     Ok(())
 }
 
-fn is_modifier(key: Key) -> bool {
+fn is_modifier(key: &str) -> bool {
     matches!(
-        key,
-        Key::Alt
-            | Key::AltGr
-            | Key::ShiftLeft
-            | Key::ShiftRight
-            | Key::ControlLeft
-            | Key::ControlRight
-            | Key::MetaLeft
-            | Key::MetaRight
+        key.to_ascii_lowercase().as_str(),
+        "alt" | "option" | "opt" | "shift" | "shiftleft" | "shiftright" | "control" |
+        "ctrl" | "controlleft" | "controlright" | "meta" | "metaleft" | "metaright" | "command" | "cmd"
     )
 }


### PR DESCRIPTION
## Summary
- Register global hotkeys using platform APIs instead of rdev
- Store hotkeys as string names in config and GUI
- Add Windows and macOS specific key mapping logic

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_689a58de5ad083339f79d89a09758645