### PR TITLE
Add macOS overlay app and build script

### DIFF
--- a/macos/KbdLayoutOverlay/AppDelegate.h
+++ b/macos/KbdLayoutOverlay/AppDelegate.h
@@ -1,0 +1,4 @@
+#import <Cocoa/Cocoa.h>
+
+@interface AppDelegate : NSObject <NSApplicationDelegate>
+@end

--- a/macos/KbdLayoutOverlay/AppDelegate.m
+++ b/macos/KbdLayoutOverlay/AppDelegate.m
@@ -1,0 +1,73 @@
+#import "AppDelegate.h"
+#import <Carbon/Carbon.h>
+#import "OverlayView.h"
+
+static OSStatus hotKeyHandler(EventHandlerCallRef nextHandler, EventRef event, void *userData);
+
+@implementation AppDelegate {
+    EventHotKeyRef _hotKeyRef;
+    EventHandlerRef _eventHandler;
+    NSPanel *_panel;
+    OverlayView *_overlayView;
+}
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
+    [self createOverlay];
+
+    EventTypeSpec eventType;
+    eventType.eventClass = kEventClassKeyboard;
+    eventType.eventKind = kEventHotKeyPressed;
+    InstallApplicationEventHandler(&hotKeyHandler, 1, &eventType, (__bridge void *)self, &_eventHandler);
+
+    EventHotKeyID hotKeyID;
+    hotKeyID.signature = 'kblo';
+    hotKeyID.id = 1;
+    RegisterEventHotKey(kVK_ANSI_O, cmdKey + shiftKey, hotKeyID, GetApplicationEventTarget(), 0, &_hotKeyRef);
+
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+}
+
+- (void)applicationWillTerminate:(NSNotification *)notification {
+    if (_hotKeyRef) {
+        UnregisterEventHotKey(_hotKeyRef);
+    }
+    if (_eventHandler) {
+        RemoveEventHandler(_eventHandler);
+    }
+}
+
+- (void)createOverlay {
+    NSRect rect = NSMakeRect(100, 100, 300, 100);
+    _panel = [[NSPanel alloc] initWithContentRect:rect
+                                        styleMask:NSWindowStyleMaskBorderless
+                                          backing:NSBackingStoreBuffered
+                                            defer:NO];
+    [_panel setOpaque:NO];
+    [_panel setBackgroundColor:[NSColor clearColor]];
+    [_panel setLevel:NSStatusWindowLevel];
+    [_panel setIgnoresMouseEvents:YES];
+
+    _overlayView = [[OverlayView alloc] initWithFrame:rect];
+    [_panel setContentView:_overlayView];
+    [_overlayView cacheSampleBuffer];
+}
+
+- (void)togglePanel {
+    if ([_panel isVisible]) {
+        [_panel orderOut:nil];
+    } else {
+        [_panel orderFront:nil];
+    }
+}
+
+@end
+
+static OSStatus hotKeyHandler(EventHandlerCallRef nextHandler, EventRef event, void *userData) {
+    AppDelegate *self = (__bridge AppDelegate *)userData;
+    EventHotKeyID hkCom;
+    GetEventParameter(event, kEventParamDirectObject, typeEventHotKeyID, NULL, sizeof(hkCom), NULL, &hkCom);
+    if (hkCom.id == 1 && GetEventKind(event) == kEventHotKeyPressed) {
+        [self togglePanel];
+    }
+    return noErr;
+}

--- a/macos/KbdLayoutOverlay/OverlayView.h
+++ b/macos/KbdLayoutOverlay/OverlayView.h
@@ -1,0 +1,5 @@
+#import <Cocoa/Cocoa.h>
+
+@interface OverlayView : NSView
+- (void)cacheSampleBuffer;
+@end

--- a/macos/KbdLayoutOverlay/OverlayView.m
+++ b/macos/KbdLayoutOverlay/OverlayView.m
@@ -1,0 +1,47 @@
+#import "OverlayView.h"
+#import <CoreGraphics/CoreGraphics.h>
+
+@interface OverlayView ()
+@property (nonatomic) CGImageRef buffer;
+@end
+
+@implementation OverlayView
+
+- (void)dealloc {
+    if (_buffer) {
+        CGImageRelease(_buffer);
+    }
+}
+
+- (void)cacheSampleBuffer {
+    size_t width = 300;
+    size_t height = 100;
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    CGContextRef ctx = CGBitmapContextCreate(NULL, width, height, 8, width * 4,
+                                            colorSpace, kCGImageAlphaPremultipliedLast);
+    CGColorSpaceRelease(colorSpace);
+
+    CGContextSetRGBFillColor(ctx, 0, 0, 0, 0.5);
+    CGContextFillRect(ctx, CGRectMake(0, 0, width, height));
+    CGContextSetRGBStrokeColor(ctx, 1, 0, 0, 1);
+    CGContextSetLineWidth(ctx, 4);
+    CGContextStrokeRect(ctx, CGRectMake(2, 2, width - 4, height - 4));
+
+    if (_buffer) {
+        CGImageRelease(_buffer);
+    }
+    _buffer = CGBitmapContextCreateImage(ctx);
+    CGContextRelease(ctx);
+}
+
+- (void)drawRect:(NSRect)dirtyRect {
+    [super drawRect:dirtyRect];
+    if (self.buffer) {
+        CGContextRef ctx = [[NSGraphicsContext currentContext] CGContext];
+        size_t width = CGImageGetWidth(self.buffer);
+        size_t height = CGImageGetHeight(self.buffer);
+        CGContextDrawImage(ctx, CGRectMake(0, 0, width, height), self.buffer);
+    }
+}
+
+@end

--- a/macos/KbdLayoutOverlay/main.m
+++ b/macos/KbdLayoutOverlay/main.m
@@ -1,0 +1,11 @@
+#import <Cocoa/Cocoa.h>
+#import "AppDelegate.h"
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        NSApplication *app = [NSApplication sharedApplication];
+        AppDelegate *delegate = [[AppDelegate alloc] init];
+        [app setDelegate:delegate];
+        return NSApplicationMain(argc, argv);
+    }
+}

--- a/macos/LaunchAgents/com.example.kbdlayoutoverlay.plist
+++ b/macos/LaunchAgents/com.example.kbdlayoutoverlay.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.example.kbdlayoutoverlay</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Applications/Kbd Layout Overlay.app/Contents/MacOS/KbdLayoutOverlay</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>

--- a/macos/README.md
+++ b/macos/README.md
@@ -1,3 +1,17 @@
 # macOS Platform
 
-Platform-specific sources and build scripts for macOS will reside here.
+This directory contains a minimal Cocoa application for the keyboard layout overlay.
+
+## Building
+
+Run `build_macos.sh` on macOS. It uses `clang` to create the `Kbd Layout Overlay.app` bundle:
+
+```sh
+./build_macos.sh
+```
+
+To install and load the LaunchAgent for autostart, pass `--install`:
+
+```sh
+./build_macos.sh --install
+```

--- a/macos/build_macos.sh
+++ b/macos/build_macos.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC_DIR="$ROOT_DIR/KbdLayoutOverlay"
+BUILD_DIR="$ROOT_DIR/build"
+APP_NAME="Kbd Layout Overlay"
+APP_DIR="$BUILD_DIR/$APP_NAME.app"
+
+mkdir -p "$APP_DIR/Contents/MacOS"
+mkdir -p "$APP_DIR/Contents/Resources"
+
+cat > "$APP_DIR/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>Kbd Layout Overlay</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.kbdlayoutoverlay</string>
+    <key>CFBundleExecutable</key>
+    <string>KbdLayoutOverlay</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+</dict>
+</plist>
+PLIST
+
+clang -fobjc-arc -framework Cocoa -framework Carbon \
+      "$SRC_DIR/main.m" "$SRC_DIR/AppDelegate.m" "$SRC_DIR/OverlayView.m" \
+      -o "$APP_DIR/Contents/MacOS/KbdLayoutOverlay"
+
+echo "Built $APP_DIR"
+
+if [[ "$1" == "--install" ]]; then
+    PLIST_SRC="$ROOT_DIR/LaunchAgents/com.example.kbdlayoutoverlay.plist"
+    DEST="$HOME/Library/LaunchAgents"
+    mkdir -p "$DEST"
+    cp "$PLIST_SRC" "$DEST/"
+    launchctl unload "$DEST/com.example.kbdlayoutoverlay.plist" 2>/dev/null || true
+    launchctl load "$DEST/com.example.kbdlayoutoverlay.plist"
+    echo "LaunchAgent loaded"
+fi


### PR DESCRIPTION
## Summary
- Add minimal Cocoa application that registers a global hotkey and toggles a transparent overlay panel.
- Draw cached CoreGraphics buffer in an `NSPanel` and support autostart via LaunchAgent.
- Provide `build_macos.sh` to build the app and optionally install the LaunchAgent with `launchctl`.

## Testing
- `./macos/build_macos.sh` *(fails: -fobjc-arc is not supported on platforms using the legacy runtime)*

------
https://chatgpt.com/codex/tasks/task_e_689a6cbac2108333be5af4669f3c4a45