### PR TITLE
Use shared overlay image in macOS app

### DIFF
--- a/macos/KbdLayoutOverlay/OverlayView.h
+++ b/macos/KbdLayoutOverlay/OverlayView.h
@@ -1,5 +1,5 @@
 #import <Cocoa/Cocoa.h>
 
 @interface OverlayView : NSView
-- (void)cacheSampleBuffer;
+- (void)setImageData:(const unsigned char *)data width:(int)width height:(int)height;
 @end


### PR DESCRIPTION
## Summary
- load overlay image with shared helper and apply configured opacity/inversion
- render RGBA buffer in OverlayView and size panel using screen scale

## Testing
- `gcc -c shared/overlay.c && ls -l overlay.o`
- `gcc -fsyntax-only macos/KbdLayoutOverlay/AppDelegate.m` *(fails: cannot execute cc1obj)*

------
https://chatgpt.com/codex/tasks/task_e_689a75af862c83338730e9e5ef606d1f