### PR TITLE
Add tray icons with autostart toggles

### DIFF
--- a/macos/KbdLayoutOverlay/AppDelegate.m
+++ b/macos/KbdLayoutOverlay/AppDelegate.m
@@ -1,6 +1,8 @@
 #import "AppDelegate.h"
 #import <Carbon/Carbon.h>
 #import "OverlayView.h"
+#import "../shared/config.h"
+#include <string.h>
 
 static OSStatus hotKeyHandler(EventHandlerCallRef nextHandler, EventRef event, void *userData);
 
@@ -9,10 +11,23 @@ static OSStatus hotKeyHandler(EventHandlerCallRef nextHandler, EventRef event, v
     EventHandlerRef _eventHandler;
     NSPanel *_panel;
     OverlayView *_overlayView;
+    NSStatusItem *_statusItem;
+    Config _cfg;
+    NSString *_configPath;
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
+    _configPath = [@"~/Library/Preferences/kbd_layout_overlay.cfg" stringByExpandingTildeInPath];
+    if (load_config([_configPath fileSystemRepresentation], &_cfg) != 0) {
+        strcpy(_cfg.overlay_path, "keymap.png");
+        _cfg.opacity = 1.0f;
+        _cfg.invert = 0;
+        _cfg.autostart = 0;
+        save_config([_configPath fileSystemRepresentation], &_cfg);
+    }
+
     [self createOverlay];
+    [self setupStatusItem];
 
     EventTypeSpec eventType;
     eventType.eventClass = kEventClassKeyboard;
@@ -57,6 +72,50 @@ static OSStatus hotKeyHandler(EventHandlerCallRef nextHandler, EventRef event, v
         [_panel orderOut:nil];
     } else {
         [_panel orderFront:nil];
+    }
+}
+
+- (void)setupStatusItem {
+    _statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSSquareStatusItemLength];
+    _statusItem.button.title = @"KLO";
+    NSMenu *menu = [[NSMenu alloc] init];
+    NSMenuItem *startItem = [[NSMenuItem alloc] initWithTitle:@"Start at login" action:@selector(toggleAutostart:) keyEquivalent:@""];
+    [startItem setTarget:self];
+    [startItem setState:_cfg.autostart ? NSControlStateValueOn : NSControlStateValueOff];
+    [menu addItem:startItem];
+    [menu addItem:[NSMenuItem separatorItem]];
+    NSMenuItem *quitItem = [[NSMenuItem alloc] initWithTitle:@"Quit" action:@selector(quit:) keyEquivalent:@""];
+    [quitItem setTarget:self];
+    [menu addItem:quitItem];
+    _statusItem.menu = menu;
+}
+
+- (void)toggleAutostart:(id)sender {
+    _cfg.autostart = !_cfg.autostart;
+    [sender setState:_cfg.autostart ? NSControlStateValueOn : NSControlStateValueOff];
+    [self setAutostart:_cfg.autostart];
+    save_config([_configPath fileSystemRepresentation], &_cfg);
+}
+
+- (void)quit:(id)sender {
+    [NSApp terminate:nil];
+}
+
+- (void)setAutostart:(BOOL)enable {
+    NSString *src = [[NSBundle mainBundle] pathForResource:@"com.example.kbdlayoutoverlay" ofType:@"plist"]; 
+    NSString *dst = [@"~/Library/LaunchAgents/com.example.kbdlayoutoverlay.plist" stringByExpandingTildeInPath];
+    if (enable) {
+        [[NSFileManager defaultManager] copyItemAtPath:src toPath:dst error:nil];
+        NSTask *task = [[NSTask alloc] init];
+        [task setLaunchPath:@"/bin/launchctl"];
+        [task setArguments:@[@"load", dst]];
+        [task launch];
+    } else {
+        NSTask *task = [[NSTask alloc] init];
+        [task setLaunchPath:@"/bin/launchctl"];
+        [task setArguments:@[@"unload", dst]];
+        [task launch];
+        [[NSFileManager defaultManager] removeItemAtPath:dst error:nil];
     }
 }
 

--- a/shared/config.c
+++ b/shared/config.c
@@ -20,6 +20,7 @@ int load_config(const char *path, Config *cfg) {
     cfg->overlay_path[0] = '\0';
     cfg->opacity = 1.0f;
     cfg->invert = 0;
+    cfg->autostart = 0;
     char line[512];
     while (fgets(line, sizeof(line), f)) {
         trim(line);
@@ -38,8 +39,21 @@ int load_config(const char *path, Config *cfg) {
             cfg->opacity = strtof(val, NULL);
         } else if (strcmp(key, "invert") == 0) {
             cfg->invert = atoi(val);
+        } else if (strcmp(key, "autostart") == 0) {
+            cfg->autostart = atoi(val);
         }
     }
+    fclose(f);
+    return 0;
+}
+
+int save_config(const char *path, const Config *cfg) {
+    FILE *f = fopen(path, "w");
+    if (!f) return -1;
+    fprintf(f, "overlay_path=%s\n", cfg->overlay_path);
+    fprintf(f, "opacity=%f\n", cfg->opacity);
+    fprintf(f, "invert=%d\n", cfg->invert);
+    fprintf(f, "autostart=%d\n", cfg->autostart);
     fclose(f);
     return 0;
 }

--- a/shared/config.h
+++ b/shared/config.h
@@ -9,10 +9,13 @@ typedef struct {
     char overlay_path[256];
     float opacity; /* 0.0 - 1.0 */
     int invert; /* 0 or 1 */
+    int autostart; /* 0 or 1 */
 } Config;
 
 /* Load key=value config file */
 int load_config(const char *path, Config *cfg);
+/* Save config back to file */
+int save_config(const char *path, const Config *cfg);
 
 #ifdef __cplusplus
 }

--- a/windows/main.c
+++ b/windows/main.c
@@ -1,30 +1,44 @@
 #include <windows.h>
+#include <shellapi.h>
 #include <stdio.h>
 #include <string.h>
+#include "../shared/config.h"
 #include "../shared/overlay.h"
 
 static Overlay g_overlay;
 static HBITMAP g_bitmap;
 static HWND g_hwnd;
+static Config g_cfg;
+static NOTIFYICONDATAA g_nid;
+static char g_cfg_path[MAX_PATH] = "config.cfg";
+#define WM_TRAY (WM_APP + 1)
 
-static void register_autostart(void) {
+static void set_autostart(int enable) {
     HKEY key;
     if (RegCreateKeyExA(HKEY_CURRENT_USER,
             "Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, NULL, 0,
             KEY_SET_VALUE, NULL, &key, NULL) == ERROR_SUCCESS) {
-        char path[MAX_PATH];
-        GetModuleFileNameA(NULL, path, MAX_PATH);
-        RegSetValueExA(key, "kbd_layout_overlay", 0, REG_SZ,
-            (const BYTE *)path, (DWORD)(strlen(path) + 1));
+        if (enable) {
+            char path[MAX_PATH];
+            GetModuleFileNameA(NULL, path, MAX_PATH);
+            RegSetValueExA(key, "kbd_layout_overlay", 0, REG_SZ,
+                (const BYTE *)path, (DWORD)(strlen(path) + 1));
+        } else {
+            RegDeleteValueA(key, "kbd_layout_overlay");
+        }
         RegCloseKey(key);
     }
 }
 
 static int init_bitmap(void) {
-    if (load_overlay_image("keymap.png", &g_overlay) != 0) {
-        MessageBoxA(NULL, "Failed to load keymap.png", "Error", MB_OK);
+    const char *path = g_cfg.overlay_path[0] ? g_cfg.overlay_path : "keymap.png";
+    if (load_overlay_image(path, &g_overlay) != 0) {
+        char msg[256];
+        sprintf(msg, "Failed to load %s", path);
+        MessageBoxA(NULL, msg, "Error", MB_OK);
         return 0;
     }
+    apply_opacity_inversion(&g_overlay, g_cfg.opacity, g_cfg.invert);
 
     BITMAPV5HEADER bi = {0};
     bi.bV5Size = sizeof(BITMAPV5HEADER);
@@ -68,6 +82,17 @@ static void update_window(void) {
 
 LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     switch (msg) {
+    case WM_TRAY:
+        if (lParam == WM_RBUTTONUP) {
+            HMENU menu = CreatePopupMenu();
+            AppendMenuA(menu, MF_STRING | (g_cfg.autostart ? MF_CHECKED : 0), 1, "Start at login");
+            AppendMenuA(menu, MF_STRING, 2, "Quit");
+            POINT p; GetCursorPos(&p);
+            SetForegroundWindow(hwnd);
+            TrackPopupMenu(menu, TPM_LEFTALIGN | TPM_BOTTOMALIGN, p.x, p.y, 0, hwnd, NULL);
+            DestroyMenu(menu);
+        }
+        break;
     case WM_HOTKEY:
         if (wParam == 1) {
             static int visible = 0;
@@ -75,7 +100,17 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             ShowWindow(hwnd, visible ? SW_SHOW : SW_HIDE);
         }
         break;
+    case WM_COMMAND:
+        if (LOWORD(wParam) == 1) {
+            g_cfg.autostart = !g_cfg.autostart;
+            set_autostart(g_cfg.autostart);
+            save_config(g_cfg_path, &g_cfg);
+        } else if (LOWORD(wParam) == 2) {
+            PostMessage(hwnd, WM_CLOSE, 0, 0);
+        }
+        break;
     case WM_DESTROY:
+        Shell_NotifyIconA(NIM_DELETE, &g_nid);
         UnregisterHotKey(NULL, 1);
         PostQuitMessage(0);
         break;
@@ -84,7 +119,14 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 }
 
 int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpCmdLine, int nShow) {
-    register_autostart();
+    if (load_config(g_cfg_path, &g_cfg) != 0) {
+        strcpy(g_cfg.overlay_path, "keymap.png");
+        g_cfg.opacity = 1.0f;
+        g_cfg.invert = 0;
+        g_cfg.autostart = 0;
+        save_config(g_cfg_path, &g_cfg);
+    }
+    set_autostart(g_cfg.autostart);
 
     if (!init_bitmap()) {
         return 0;
@@ -102,6 +144,15 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpCmdLine, int nShow)
 
     update_window();
     ShowWindow(g_hwnd, SW_HIDE);
+
+    g_nid.cbSize = sizeof(g_nid);
+    g_nid.hWnd = g_hwnd;
+    g_nid.uID = 1;
+    g_nid.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
+    g_nid.uCallbackMessage = WM_TRAY;
+    g_nid.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+    lstrcpyA(g_nid.szTip, "Keyboard Layout Overlay");
+    Shell_NotifyIconA(NIM_ADD, &g_nid);
 
     RegisterHotKey(NULL, 1, MOD_CONTROL | MOD_ALT | MOD_SHIFT, VK_OEM_2);
 


### PR DESCRIPTION
## Summary
- extend config with autostart flag and persistence helpers
- show system tray/NSStatusItem menus on Windows and macOS with Start at login and Quit
- wire menu actions to update config and register/unregister autostart

## Testing
- `make -C shared clean && make -C shared`


------
https://chatgpt.com/codex/tasks/task_e_689a6fedaea08333b037402a8986488b