### PR TITLE
Add invert colors menu toggle

### DIFF
--- a/macos/KbdLayoutOverlay/AppDelegate.m
+++ b/macos/KbdLayoutOverlay/AppDelegate.m
@@ -83,6 +83,10 @@ static OSStatus hotKeyHandler(EventHandlerCallRef nextHandler, EventRef event, v
     [startItem setTarget:self];
     [startItem setState:_cfg.autostart ? NSControlStateValueOn : NSControlStateValueOff];
     [menu addItem:startItem];
+    NSMenuItem *invertItem = [[NSMenuItem alloc] initWithTitle:@"Invert colors" action:@selector(toggleInvert:) keyEquivalent:@""];
+    [invertItem setTarget:self];
+    [invertItem setState:_cfg.invert ? NSControlStateValueOn : NSControlStateValueOff];
+    [menu addItem:invertItem];
     [menu addItem:[NSMenuItem separatorItem]];
     NSMenuItem *quitItem = [[NSMenuItem alloc] initWithTitle:@"Quit" action:@selector(quit:) keyEquivalent:@""];
     [quitItem setTarget:self];
@@ -99,6 +103,14 @@ static OSStatus hotKeyHandler(EventHandlerCallRef nextHandler, EventRef event, v
 
 - (void)quit:(id)sender {
     [NSApp terminate:nil];
+}
+
+- (void)toggleInvert:(id)sender {
+    _cfg.invert = !_cfg.invert;
+    [sender setState:_cfg.invert ? NSControlStateValueOn : NSControlStateValueOff];
+    [_overlayView cacheSampleBuffer];
+    [_overlayView setNeedsDisplay:YES];
+    save_config([_configPath fileSystemRepresentation], &_cfg);
 }
 
 - (void)setAutostart:(BOOL)enable {


### PR DESCRIPTION
## Summary
- add an “Invert colors” toggle to the Windows tray menu and update bitmap when used
- expose the same toggle in the macOS status menu and refresh the overlay view

## Testing
- `bash macos/build_macos.sh` *(fails: clang: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a75b0be2c8333a3240000f5635f84