### PR TITLE
Add Windows and macOS build workflows with signing placeholders

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,45 @@
+name: macOS Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    env:
+      MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      TEAM_ID: ${{ secrets.TEAM_ID }}
+      APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: ./build_macos.sh
+        working-directory: macos
+      - name: Sign app
+        if: env.MACOS_SIGNING_IDENTITY != ''
+        run: codesign --deep --force --options runtime --sign "$MACOS_SIGNING_IDENTITY" "build/Kbd Layout Overlay.app"
+        working-directory: macos
+      - name: Create zip bundle
+        run: |
+          cd build
+          zip -r kbd_layout_overlay-macos.zip "Kbd Layout Overlay.app"
+        working-directory: macos
+      - name: Notarize app
+        if: env.APPLE_ID != '' && env.TEAM_ID != '' && env.APPLE_PASSWORD != ''
+        run: |
+          cd build
+          xcrun notarytool submit kbd_layout_overlay-macos.zip --apple-id "$APPLE_ID" --team-id "$TEAM_ID" --password "$APPLE_PASSWORD" --wait
+          xcrun stapler staple "Kbd Layout Overlay.app"
+          rm kbd_layout_overlay-macos.zip
+          zip -r kbd_layout_overlay-macos.zip "Kbd Layout Overlay.app"
+        working-directory: macos
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-build
+          path: |
+            macos/build/Kbd Layout Overlay.app
+            macos/build/kbd_layout_overlay-macos.zip
+

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,35 @@
+name: Windows Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    env:
+      WINDOWS_CERT_FILE: ${{ secrets.WINDOWS_CERT_FILE }}
+      WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: build_windows.bat
+        working-directory: windows
+        shell: cmd
+      - name: Sign executable
+        if: env.WINDOWS_CERT_FILE != ''
+        run: signtool sign /f "%WINDOWS_CERT_FILE%" /p "%WINDOWS_CERT_PASSWORD%" kbd_layout_overlay.exe
+        working-directory: windows
+        shell: cmd
+      - name: Create zip bundle
+        run: Compress-Archive -Path kbd_layout_overlay.exe -DestinationPath kbd_layout_overlay-windows.zip
+        working-directory: windows
+        shell: pwsh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-build
+          path: |
+            windows/kbd_layout_overlay.exe
+            windows/kbd_layout_overlay-windows.zip
+

--- a/macos/README.md
+++ b/macos/README.md
@@ -15,3 +15,21 @@ To install and load the LaunchAgent for autostart, pass `--install`:
 ```sh
 ./build_macos.sh --install
 ```
+
+## Signing and Notarization
+
+With a Developer ID certificate the app can be signed and notarized before distribution:
+
+```sh
+# Sign
+codesign --deep --force --options runtime --sign "Developer ID Application: Example (TEAMID)" build/Kbd\ Layout\ Overlay.app
+
+# Notarize
+cd build
+zip -r kbd_layout_overlay-macos.zip "Kbd Layout Overlay.app"
+xcrun notarytool submit kbd_layout_overlay-macos.zip --apple-id <apple-id> --team-id <team-id> --password <app-specific-password> --wait
+xcrun stapler staple "Kbd Layout Overlay.app"
+```
+
+The `macos.yml` GitHub workflow performs these steps automatically when `MACOS_SIGNING_IDENTITY`, `APPLE_ID`, `TEAM_ID`, and `APPLE_PASSWORD` secrets are configured.
+

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,3 +1,18 @@
 # Windows Platform
 
 Platform-specific sources and build scripts for Windows will reside here.
+
+## Building
+
+Run `build_windows.bat` in a Visual Studio Developer Command Prompt to produce `kbd_layout_overlay.exe`.
+
+## Signing
+
+When a code signing certificate is available the executable can be signed with `signtool`:
+
+```cmd
+signtool sign /f <path-to-cert.pfx> /p <password> kbd_layout_overlay.exe
+```
+
+The `windows.yml` GitHub workflow will use `WINDOWS_CERT_FILE` and `WINDOWS_CERT_PASSWORD` secrets to sign automatically and will upload both the `.exe` and a zipped bundle.
+


### PR DESCRIPTION
## Summary
- add Windows GitHub Actions workflow to build, optionally sign, and zip the executable
- add macOS workflow with optional codesign/notarize steps and zip bundle
- document signing and notarization instructions for Windows and macOS

## Testing
- `bash -n macos/build_macos.sh`


------
https://chatgpt.com/codex/tasks/task_e_689a9874dc888333b07fce8d2406f451