### PR TITLE
Add opacity controls to menus

### DIFF
--- a/macos/KbdLayoutOverlay/AppDelegate.m
+++ b/macos/KbdLayoutOverlay/AppDelegate.m
@@ -203,6 +203,9 @@ static void parseHotkey(const char *hotkey, UInt32 *keyCode, UInt32 *mods) {
     [invertItem setTarget:self];
     [invertItem setState:_cfg.invert ? NSControlStateValueOn : NSControlStateValueOff];
     [menu addItem:invertItem];
+    NSMenuItem *opacityItem = [[NSMenuItem alloc] initWithTitle:@"Cycle opacity" action:@selector(cycleOpacity:) keyEquivalent:@""];
+    [opacityItem setTarget:self];
+    [menu addItem:opacityItem];
     [menu addItem:[NSMenuItem separatorItem]];
     NSMenuItem *quitItem = [[NSMenuItem alloc] initWithTitle:@"Quit" action:@selector(quit:) keyEquivalent:@""];
     [quitItem setTarget:self];
@@ -226,6 +229,22 @@ static void parseHotkey(const char *hotkey, UInt32 *keyCode, UInt32 *mods) {
     [sender setState:_cfg.invert ? NSControlStateValueOn : NSControlStateValueOff];
     [_overlayView cacheSampleBuffer];
     [_overlayView setNeedsDisplay:YES];
+    save_config([_configPath fileSystemRepresentation], &_cfg);
+}
+
+- (void)cycleOpacity:(id)sender {
+    float levels[] = {0.25f, 0.5f, 0.75f, 1.0f};
+    int count = sizeof(levels) / sizeof(levels[0]);
+    int next = 0;
+    for (int i = 0; i < count; i++) {
+        if (_cfg.opacity <= levels[i] + 0.001f) {
+            next = (i + 1) % count;
+            break;
+        }
+    }
+    _cfg.opacity = levels[next];
+    apply_opacity_inversion(&_overlay, _cfg.opacity, _cfg.invert);
+    [_overlayView setImageData:_overlay.data width:_overlay.width height:_overlay.height];
     save_config([_configPath fileSystemRepresentation], &_cfg);
 }
 

--- a/windows/main.c
+++ b/windows/main.c
@@ -88,6 +88,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             HMENU menu = CreatePopupMenu();
             AppendMenuA(menu, MF_STRING | (g_cfg.autostart ? MF_CHECKED : 0), 1, "Start at login");
             AppendMenuA(menu, MF_STRING | (g_cfg.invert ? MF_CHECKED : 0), 3, "Invert colors");
+            AppendMenuA(menu, MF_STRING, 4, "Cycle opacity");
             AppendMenuA(menu, MF_STRING, 2, "Quit");
             POINT p; GetCursorPos(&p);
             SetForegroundWindow(hwnd);
@@ -111,6 +112,21 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             PostMessage(hwnd, WM_CLOSE, 0, 0);
         } else if (LOWORD(wParam) == 3) {
             g_cfg.invert = !g_cfg.invert;
+            apply_opacity_inversion(&g_overlay, g_cfg.opacity, g_cfg.invert);
+            memcpy(g_bits, g_overlay.data, (size_t)g_overlay.width * g_overlay.height * 4);
+            update_window();
+            save_config(g_cfg_path, &g_cfg);
+        } else if (LOWORD(wParam) == 4) {
+            float levels[] = {0.25f, 0.5f, 0.75f, 1.0f};
+            int count = sizeof(levels) / sizeof(levels[0]);
+            int next = 0;
+            for (int i = 0; i < count; i++) {
+                if (g_cfg.opacity <= levels[i] + 0.001f) {
+                    next = (i + 1) % count;
+                    break;
+                }
+            }
+            g_cfg.opacity = levels[next];
             apply_opacity_inversion(&g_overlay, g_cfg.opacity, g_cfg.invert);
             memcpy(g_bits, g_overlay.data, (size_t)g_overlay.width * g_overlay.height * 4);
             update_window();


### PR DESCRIPTION
## Summary
- Allow cycling preset opacity levels from the Windows tray menu and apply changes immediately
- Add macOS status bar menu item to cycle overlay opacity and save settings

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689a99a0717883338556d67f034e22b3