### PR TITLE
Set up MSVC environment for Windows benchmark

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,34 @@
+name: Performance Benchmark
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  benchmark:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install hyperfine
+        run: brew install hyperfine
+      - name: Run benchmark
+        run: scripts/benchmark_overlay.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: overlay-benchmark
+          path: benchmark_results.txt
+
+  benchmark-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install hyperfine
+        run: choco install hyperfine -y
+      - name: Run benchmark
+        run: scripts/benchmark_overlay.ps1
+        shell: pwsh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: overlay-benchmark-windows
+          path: benchmark_results.txt

--- a/scripts/benchmark_overlay.ps1
+++ b/scripts/benchmark_overlay.ps1
@@ -1,0 +1,55 @@
+$ErrorActionPreference = 'Stop'
+$root = (Get-Item "$PSScriptRoot/..\").FullName
+Set-Location $root
+
+# Ensure MSVC tools are available
+$vsPath = & vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+if (-not $vsPath) {
+    throw 'MSVC build tools not found'
+}
+$vcvars = Join-Path $vsPath 'VC\Auxiliary\Build\vcvars64.bat'
+cmd /c "`"$vcvars`" >nul && set" | ForEach-Object {
+    if ($_ -match '^(.*?)=(.*)$') {
+        Set-Item -Path "Env:$($matches[1])" -Value $matches[2]
+    }
+}
+
+# Build the project
+& "$root\windows\build_windows.bat"
+
+# Create temporary benchmark program for apply_opacity_inversion
+$benchC = Join-Path ([System.IO.Path]::GetTempPath()) "bench_overlay.c"
+@'
+#include "overlay.h"
+#include <stdlib.h>
+
+int main(void) {
+    Overlay img;
+    img.width = 1920;
+    img.height = 1080;
+    img.channels = 4;
+    img.data = malloc((size_t)img.width * img.height * 4);
+    if (!img.data) return 1;
+    for (size_t i = 0; i < (size_t)img.width * img.height * 4; ++i) {
+        img.data[i] = (unsigned char)(i);
+    }
+    for (int i = 0; i < 100; ++i) {
+        apply_opacity_inversion(&img, 0.5f, 1);
+    }
+    free(img.data);
+    return 0;
+}
+'@ | Set-Content $benchC
+
+$benchExe = Join-Path ([System.IO.Path]::GetTempPath()) "bench_overlay.exe"
+& cl /nologo /O2 $benchC "$root\shared\overlay.c" /I "$root\shared" /Fe:$benchExe | Out-Null
+
+$outFile = Join-Path $root "benchmark_results.txt"
+if (Get-Command hyperfine -ErrorAction SilentlyContinue) {
+    hyperfine $benchExe | Tee-Object -FilePath $outFile
+} else {
+    "hyperfine not found; using Measure-Command" | Tee-Object -FilePath $outFile
+    (Measure-Command { & $benchExe } | Out-String) | Tee-Object -FilePath $outFile -Append
+}
+Write-Host "Benchmark results written to $outFile"
+

--- a/scripts/benchmark_overlay.sh
+++ b/scripts/benchmark_overlay.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Build the project
+./macos/build_macos.sh
+
+# Create temporary benchmark program for apply_opacity_inversion
+BENCH_C=$(mktemp)
+cat > "$BENCH_C" <<'C_EOF'
+#include "overlay.h"
+#include <stdlib.h>
+
+int main(void) {
+    Overlay img;
+    img.width = 1920;
+    img.height = 1080;
+    img.channels = 4;
+    img.data = malloc((size_t)img.width * img.height * 4);
+    if (!img.data) return 1;
+    for (size_t i = 0; i < (size_t)img.width * img.height * 4; ++i) {
+        img.data[i] = (unsigned char)(i);
+    }
+    for (int i = 0; i < 100; ++i) {
+        apply_opacity_inversion(&img, 0.5f, 1);
+    }
+    free(img.data);
+    return 0;
+}
+C_EOF
+
+BENCH_EXE=$(mktemp)
+cc -O2 -std=c99 "$BENCH_C" "$ROOT_DIR/shared/overlay.c" -I"$ROOT_DIR/shared" -o "$BENCH_EXE"
+
+OUT_FILE="$ROOT_DIR/benchmark_results.txt"
+if command -v hyperfine >/dev/null 2>&1; then
+    hyperfine "$BENCH_EXE" | tee "$OUT_FILE"
+else
+    echo "hyperfine not found; using time instead" | tee "$OUT_FILE"
+    /usr/bin/time -p "$BENCH_EXE" 2>&1 | tee -a "$OUT_FILE"
+fi
+
+echo "Benchmark results written to $OUT_FILE"

--- a/windows/build_windows.bat
+++ b/windows/build_windows.bat
@@ -1,6 +1,16 @@
 @echo off
 setlocal
 echo Building kbd_layout_overlay
+
+:: Locate and load the Visual Studio build environment
+for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set VS_PATH=%%i
+if not defined VS_PATH (
+    echo Visual Studio Build Tools not found.
+    exit /b 1
+)
+call "%VS_PATH%\VC\Auxiliary\Build\vcvars64.bat" >nul
+
 rc /fo resource.res resource.rc
 cl /O2 main.c ..\shared\overlay.c ..\shared\config.c resource.res user32.lib gdi32.lib /Fe:kbd_layout_overlay.exe /link /SUBSYSTEM:WINDOWS
+endlocal
 


### PR DESCRIPTION
## Summary
- Initialize Visual Studio environment in `build_windows.bat` so `cl` and `rc` are available and ensure proper `/SUBSYSTEM:WINDOWS` linking
- Prepare PowerShell benchmark script to load MSVC toolchain before building and benchmarking

## Testing
- `pwsh scripts/benchmark_overlay.ps1` *(fails: command not found)*
- `wine cmd /c windows/build_windows.bat` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e2e4a795c83339aa2e69c705e19f0