### PR TITLE
docs: drop logging references

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Settings are stored in a simple `key=value` file.
 | `autostart`   | `1` launches the app at login, `0` disables autostart. |
 | `hotkey`      | `+` separated list of modifiers and key, e.g. `Ctrl+Alt+K` or `Command+Option+K`. |
 | `persistent`  | `1` toggles the overlay, `0` shows it only while keys are held. |
-| `log`         | Logging level: `error`, `warn`, `info`, `debug`, or `trace`. |
 
 Edit the file with any text editor:
 
@@ -52,7 +51,6 @@ kbd_layout_overlay autostart enable   # register
 kbd_layout_overlay autostart disable  # unregister
 ```
 
-Use `--log-level <level>` (alias `--logs`) or set `log=<level>` in the configuration file to adjust verbosity for troubleshooting.
 
 On Windows this creates or removes a registry entry under `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`. On macOS a `LaunchAgents` plist is created or deleted.
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -16,10 +16,6 @@ To install and load the LaunchAgent for autostart, pass `--install`:
 ./build_macos.sh --install
 ```
 
-## Logging
-
-For troubleshooting, run the built application with `--log-level debug` (alias `--logs`) or set `log="debug"` in the configuration file to increase verbosity.
-
 ## Signing and Notarization
 
 With a Developer ID certificate the app can be signed and notarized before distribution:

--- a/windows/README.md
+++ b/windows/README.md
@@ -14,9 +14,5 @@ When a code signing certificate is available the executable can be signed with `
 signtool sign /f <path-to-cert.pfx> /p <password> kbd_layout_overlay.exe
 ```
 
-## Logging
-
-Use `--log-level debug` (alias `--logs`) or set `log="debug"` in the configuration file to enable verbose output when running the executable.
-
 The `windows.yml` GitHub workflow will use `WINDOWS_CERT_FILE` and `WINDOWS_CERT_PASSWORD` secrets to sign automatically and will upload both the `.exe` and a zipped bundle.
 


### PR DESCRIPTION
## Summary
- remove stale `log` option from configuration documentation
- drop logging sections from Windows and macOS platform guides

## Testing
- `gcc -c shared/config.c shared/hotkey.c shared/overlay.c -std=c99`


------
https://chatgpt.com/codex/tasks/task_e_689e6c61681483339ae6a09d7ca4e1c6