### PR TITLE
distinguish overlay load errors

### DIFF
--- a/shared/overlay.h
+++ b/shared/overlay.h
@@ -14,6 +14,13 @@ typedef struct {
     int channels; /* should be 4 for RGBA */
 } Overlay;
 
+enum {
+    OVERLAY_OK = 0,
+    OVERLAY_ERR_MEMORY = -1,
+    OVERLAY_ERR_NOT_FOUND = -2,
+    OVERLAY_ERR_DECODE = -3
+};
+
 int load_overlay_image(const char *path, int max_width, int max_height, Overlay *out);
 int load_overlay_image_mem(const unsigned char *buffer, int len,
                            int max_width, int max_height, Overlay *out);

--- a/windows/main.c
+++ b/windows/main.c
@@ -84,20 +84,32 @@ static int init_bitmap(void) {
     int screen_w = GetSystemMetrics(SM_CXSCREEN);
     int screen_h = GetSystemMetrics(SM_CYSCREEN);
     int r = load_overlay_image(path, screen_w, screen_h, &g_overlay);
-    if (r != 0 && !g_cfg.overlay_path[0]) {
-        HRSRC res = FindResourceA(NULL, MAKEINTRESOURCEA(IDR_KEYMAP), RT_RCDATA);
-        if (res) {
-            HGLOBAL data = LoadResource(NULL, res);
-            DWORD size = SizeofResource(NULL, res);
-            void *ptr = LockResource(data);
-            if (ptr && size) {
-                r = load_overlay_image_mem(ptr, (int)size, screen_w, screen_h, &g_overlay);
+    if (r != OVERLAY_OK) {
+        const char *fmt;
+        if (r == OVERLAY_ERR_NOT_FOUND)
+            fmt = "Overlay image not found: %s";
+        else if (r == OVERLAY_ERR_DECODE)
+            fmt = "Failed to decode overlay image: %s";
+        else
+            fmt = "Failed to load overlay image: %s";
+        char buf[256];
+        snprintf(buf, sizeof(buf), fmt, path);
+        MessageBoxA(NULL, buf, "Error", MB_OK);
+        if (!g_cfg.overlay_path[0]) {
+            HRSRC res = FindResourceA(NULL, MAKEINTRESOURCEA(IDR_KEYMAP), RT_RCDATA);
+            if (res) {
+                HGLOBAL data = LoadResource(NULL, res);
+                DWORD size = SizeofResource(NULL, res);
+                void *ptr = LockResource(data);
+                if (ptr && size) {
+                    r = load_overlay_image_mem(ptr, (int)size, screen_w, screen_h, &g_overlay);
+                }
             }
         }
-    }
-    if (r != 0) {
-        MessageBoxA(NULL, "Failed to load overlay image", "Error", MB_OK);
-        return 0;
+        if (r != OVERLAY_OK) {
+            MessageBoxA(NULL, "Failed to load overlay image", "Error", MB_OK);
+            return 0;
+        }
     }
     apply_opacity_inversion(&g_overlay, g_cfg.opacity, g_cfg.invert);
 


### PR DESCRIPTION
## Summary
- differentiate overlay loading failures with explicit error codes
- warn users when images are missing or corrupt and only fallback to built-in defaults when no custom path is set

## Testing
- `./scripts/benchmark_overlay.sh`

------
https://chatgpt.com/codex/tasks/task_e_689e6cde7f948333a7bbe18bc0387c6a