### PR TITLE
Scale overlay image to fit screen

### DIFF
--- a/shared/overlay.c
+++ b/shared/overlay.c
@@ -15,7 +15,8 @@ static int finalize_image(unsigned char *data, int width, int height,
     float scale_w = (float)max_width / (float)out->width;
     float scale_h = (float)max_height / (float)out->height;
     float scale = scale_w < scale_h ? scale_w : scale_h;
-    if (scale < 1.0f) {
+
+    if (scale != 1.0f) {
         int new_w = (int)(out->width * scale);
         int new_h = (int)(out->height * scale);
         if (new_w < 1) new_w = 1;

--- a/shared/overlay.h
+++ b/shared/overlay.h
@@ -21,6 +21,8 @@ enum {
     OVERLAY_ERR_DECODE = -3
 };
 
+/* Load an image and scale it to fit within max_width/max_height while
+   preserving aspect ratio. */
 int load_overlay_image(const char *path, int max_width, int max_height, Overlay *out);
 int load_overlay_image_mem(const unsigned char *buffer, int len,
                            int max_width, int max_height, Overlay *out);


### PR DESCRIPTION
## Summary
- Document shared overlay image loader to scale images to screen bounds.
- Scale overlay image up or down to fit current screen while preserving aspect ratio.

## Testing
- `scripts/benchmark_overlay.sh`


------
https://chatgpt.com/codex/tasks/task_e_689e74c03f488333a320e9a0c241110c