### PR TITLE
Fix Windows build errors

### DIFF
--- a/shared/config.c
+++ b/shared/config.c
@@ -3,6 +3,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#ifdef _MSC_VER
+#include <direct.h>
+#endif
 
 #ifndef PATH_MAX
 #define PATH_MAX 4096

--- a/windows/main.c
+++ b/windows/main.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <math.h>
 #include "config.h"
 #include "overlay.h"
 #include "log.h"
@@ -63,6 +64,11 @@ static HWND g_autohide_label = NULL;
 #define IDC_OPACITY_LABEL 209
 #define IDC_AUTOHIDE_SLIDER 210
 #define IDC_AUTOHIDE_LABEL 211
+
+/* Forward declarations for label update helpers */
+static void update_scale_label(void);
+static void update_opacity_label(void);
+static void update_autohide_label(void);
 
 static void cleanup_resources(void) {
     if (g_bitmap) DeleteObject(g_bitmap);


### PR DESCRIPTION
## Summary
- include math.h in the Windows app and declare label update helpers to avoid implicit function warnings and redefinition errors
- include `<direct.h>` when building on MSVC so `_mkdir` is defined

## Testing
- `gcc -Ishared tests/test_overlay.c shared/overlay.c shared/config.c shared/log.c -lm -o test_overlay.out`
- `gcc -Ishared tests/test_overlay_copy.c shared/overlay.c shared/config.c shared/log.c -lm -o test_overlay_copy.out`
- `./test_overlay.out && ./test_overlay_copy.out`


------
https://chatgpt.com/codex/tasks/task_e_68ac180bdd2083338be2b5999eb6191f