### PR TITLE
Use active monitor size for Windows overlay

### DIFF
--- a/windows/main.c
+++ b/windows/main.c
@@ -160,14 +160,18 @@ static int parse_hotkey(const char *hotkey_str, UINT *modifiers, UINT *vk) {
 static int init_overlay(void) {
     /* Determine overlay dimensions */
     int max_w, max_h;
+    /* Get active monitor dimensions */
+    RECT mon = get_monitor_rect(g_config.monitor_index);
+    int screen_w = mon.right - mon.left;
+    int screen_h = mon.bottom - mon.top;
     if (g_config.use_custom_size) {
         /* Use custom pixel dimensions */
         max_w = g_config.custom_width_px;
         max_h = g_config.custom_height_px;
     } else {
-        /* Apply configurable scaling to max dimensions */
-        max_w = (int)(1920 * g_config.scale);
-        max_h = (int)(1080 * g_config.scale);
+        /* Apply configurable scaling to monitor dimensions */
+        max_w = (int)(screen_w * g_config.scale);
+        max_h = (int)(screen_h * g_config.scale);
     }
     
     /* Try multiple locations for keymap.png */


### PR DESCRIPTION
## Summary
- derive Windows overlay dimensions from selected monitor instead of hardcoded 1920x1080

## Testing
- `cmake ..`
- `cmake --build .` *(fails: embedding keymap.png)*
- `ctest --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca23a6a748333b3666a3a801b6191