### PR TITLE
Expose preferences from tray menu

### DIFF
--- a/windows/main.c
+++ b/windows/main.c
@@ -851,6 +851,9 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             /* Open preferences for custom auto-hide setting */
             open_prefs_window();
             break;
+        case ID_PREFS_OPEN:
+            open_prefs_window();
+            break;
         case 3: /* Quit */
             PostQuitMessage(0);
             break;


### PR DESCRIPTION
## Summary
- Handle `ID_PREFS_OPEN` in the main window procedure so the Preferences window can be launched from the tray icon menu.

## Testing
- `cmake --build . --config Release`
- `cmake --build .`
- `./test_mvp`
- `./test_overlay_copy`
- `./test_overlay_scale`


------
https://chatgpt.com/codex/tasks/task_e_68aca98c3fa08333914b6ca1011aae09