### PR TITLE
refactor: remove persistent flag in favor of auto-hide

### DIFF
--- a/shared/config.c
+++ b/shared/config.c
@@ -145,7 +145,6 @@ int load_config(Config *out, const char *path) {
     int any = 0;
     if (parse_float_field(buf, "\"opacity\"", &out->opacity)) any = 1;
     if (parse_int_field(buf, "\"invert\"", &out->invert)) any = 1;
-    if (parse_int_field(buf, "\"persistent\"", &out->persistent)) any = 1;
     float scale_tmp;
     if (parse_float_field(buf, "\"scale\"", &scale_tmp)) { out->scale = scale_tmp; any = 1; }
 
@@ -160,16 +159,18 @@ int load_config(Config *out, const char *path) {
 
     /* New fields: auto_hide and positioning / general flags */
     if (parse_float_field(buf, "\"auto_hide\"", &out->auto_hide)) any = 1;
+    int legacy_persistent = 0;
+    if (parse_int_field(buf, "\"persistent\"", &legacy_persistent)) {
+        any = 1;
+        if (legacy_persistent == 1) {
+            out->auto_hide = 0.0f;
+        }
+    }
     if (parse_int_field(buf, "\"position_mode\"", &out->position_mode)) any = 1;
     if (parse_int_field(buf, "\"start_at_login\"", &out->start_at_login)) any = 1;
     if (parse_int_field(buf, "\"click_through\"", &out->click_through)) any = 1;
     if (parse_int_field(buf, "\"always_on_top\"", &out->always_on_top)) any = 1;
     if (parse_int_field(buf, "\"monitor_index\"", &out->monitor_index)) any = 1;
-
-    /* Migration: legacy persistent flag maps to auto_hide == 0.0 (persistent) */
-    if (out->persistent == 1) {
-        out->auto_hide = 0.0f;
-    }
 
     /* Clamp sensible ranges */
     if (out->auto_hide < 0.0f) out->auto_hide = 0.0f;
@@ -195,7 +196,6 @@ int save_config(const Config *cfg, const char *path) {
         "{\n"
         "  \"opacity\": %.3f,\n"
         "  \"invert\": %d,\n"
-        "  \"persistent\": %d,\n"
         "  \"hotkey\": \"%s\",\n"
         "  \"scale\": %.3f,\n"
         "  \"use_custom_size\": %d,\n"
@@ -212,7 +212,6 @@ int save_config(const Config *cfg, const char *path) {
         "}\n",
         cfg->opacity,
         cfg->invert ? 1 : 0,
-        cfg->persistent ? 1 : 0,
         cfg->hotkey,
         cfg->scale,
         cfg->use_custom_size ? 1 : 0,

--- a/shared/config.h
+++ b/shared/config.h
@@ -11,7 +11,6 @@ extern "C" {
 typedef struct {
     float opacity;
     int invert;
-    int persistent;         /* DEPRECATED: preserved for migration; persistent behavior == auto_hide == 0.0 */
     char hotkey[64];       /* Mutable hotkey string (UTF-8, e.g. "Ctrl+Alt+Shift+Slash") */
     float scale;           /* Image scale factor (0.5 = 50%, 1.0 = 100%, 2.0 = 200%) */
     int position_x;        /* X offset from center (-100 = 100px left, 100 = 100px right) */
@@ -36,7 +35,6 @@ static inline Config get_default_config(void) {
     Config config;
     config.opacity = 0.8f;
     config.invert = 0;
-    config.persistent = 0;    /* kept for migration compatibility */
     config.scale = 1.0f;
     config.position_x = 0;    /* Centered */
     config.position_y = 100;  /* 100px from bottom */

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -49,13 +49,13 @@ int main(void) {
 
     /* Test 2: legacy migration - persistent -> auto_hide == 0.0 */
     {
-        Config m = get_default_config();
-        m.persistent = 1;
-        m.auto_hide = 0.8f; /* intentionally non-zero; migration should override when loading */
-        if (!save_config(&m, path)) {
-            fprintf(stderr, "Test2: save_config failed\n");
+        FILE *f = fopen(path, "wb");
+        if (!f) {
+            fprintf(stderr, "Test2: fopen failed\n");
             return 10;
         }
+        fprintf(f, "{\n  \"persistent\": 1,\n  \"auto_hide\": 0.8\n}\n");
+        fclose(f);
 
         Config out = get_default_config();
         int r = load_config(&out, path);
@@ -66,7 +66,7 @@ int main(void) {
         }
 
         if (!float_eq(out.auto_hide, 0.0f)) {
-            fprintf(stderr, "Test2: migration failed - expected auto_hide==0.0 got %.3f (persistent=%d)\n", out.auto_hide, out.persistent);
+            fprintf(stderr, "Test2: migration failed - expected auto_hide==0.0 got %.3f\n", out.auto_hide);
             unlink(path);
             return 12;
         }

--- a/windows/main.c
+++ b/windows/main.c
@@ -342,8 +342,8 @@ static LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lP
                         if (g_key_pressed) {
                             g_key_pressed = 0;
                             logger_log("Hotkey released (vk=%u)", (unsigned)pk->vkCode);
-                            /* In non-persistent mode, hide on release; persistent mode ignores release */
-                            if (!g_config.persistent) {
+                            /* Hide on release only when auto-hide is enabled */
+                            if (g_config.auto_hide > 0.0f) {
                                 PostMessage(g_hidden_window, MSG_HIDE_OVERLAY, 0, 0);
                             }
                         }
@@ -353,7 +353,7 @@ static LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lP
                     if (g_key_pressed) {
                         g_key_pressed = 0;
                         logger_log("Hotkey modifiers changed - hiding overlay");
-                        if (!g_config.persistent) {
+                        if (g_config.auto_hide > 0.0f) {
                             PostMessage(g_hidden_window, MSG_HIDE_OVERLAY, 0, 0);
                         }
                     }
@@ -389,9 +389,9 @@ static void show_overlay(void) {
     ShowWindow(g_window, SW_SHOWNOACTIVATE);
     g_visible = 1;
     
-    /* Auto-hide timer for non-persistent mode (matching macOS behavior) */
-    if (!g_config.persistent) {
-        SetTimer(g_hidden_window, 1, 800, NULL);  // 0.8 seconds like macOS
+    /* Auto-hide timer when enabled */
+    if (g_config.auto_hide > 0.0f) {
+        SetTimer(g_hidden_window, 1, (UINT)(g_config.auto_hide * 1000), NULL);
     }
 }
 


### PR DESCRIPTION
## Summary
- switch overlay hotkey logic on Windows to use `auto_hide` instead of legacy `persistent`
- drop `persistent` from config and parse legacy field into `auto_hide`
- simplify macOS auto-hide controls and remove leftover persistent references

## Testing
- `gcc tests/test_config.c shared/config.c -Ishared -o test_config && ./test_config`
- `gcc tests/test_overlay.c shared/overlay.c -Ishared -lm -o test_overlay && ./test_overlay`
- `gcc tests/test_overlay_copy.c shared/overlay.c -Ishared -lm -o test_overlay_copy && ./test_overlay_copy`
- `gcc tests/test_overlay_scale.c shared/overlay.c -Ishared -lm -o test_overlay_scale && ./test_overlay_scale`
- `gcc test_mvp.c shared/overlay.c shared/config.c -Ishared -lm -o test_mvp`
- `./test_mvp > /tmp/test_mvp.log && tail -n 20 /tmp/test_mvp.log`


------
https://chatgpt.com/codex/tasks/task_e_68aca98e8f5c8333be624c89797c6712